### PR TITLE
Specify terminal colors for neovim

### DIFF
--- a/colors/Base2Tone_CaveDark.vim
+++ b/colors/Base2Tone_CaveDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_CaveLight.vim
+++ b/colors/Base2Tone_CaveLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_DesertDark.vim
+++ b/colors/Base2Tone_DesertDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_DesertLight.vim
+++ b/colors/Base2Tone_DesertLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_DrawbridgeDark.vim
+++ b/colors/Base2Tone_DrawbridgeDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_DrawbridgeLight.vim
+++ b/colors/Base2Tone_DrawbridgeLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_EarthDark.vim
+++ b/colors/Base2Tone_EarthDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_EarthLight.vim
+++ b/colors/Base2Tone_EarthLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_EveningDark.vim
+++ b/colors/Base2Tone_EveningDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_EveningLight.vim
+++ b/colors/Base2Tone_EveningLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_ForestDark.vim
+++ b/colors/Base2Tone_ForestDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_ForestLight.vim
+++ b/colors/Base2Tone_ForestLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_HeathDark.vim
+++ b/colors/Base2Tone_HeathDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_HeathLight.vim
+++ b/colors/Base2Tone_HeathLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_LakeDark.vim
+++ b/colors/Base2Tone_LakeDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_LakeLight.vim
+++ b/colors/Base2Tone_LakeLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_MeadowDark.vim
+++ b/colors/Base2Tone_MeadowDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_MeadowLight.vim
+++ b/colors/Base2Tone_MeadowLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_MorningDark.vim
+++ b/colors/Base2Tone_MorningDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_MorningLight.vim
+++ b/colors/Base2Tone_MorningLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_PoolDark.vim
+++ b/colors/Base2Tone_PoolDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_PoolLight.vim
+++ b/colors/Base2Tone_PoolLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_SeaDark.vim
+++ b/colors/Base2Tone_SeaDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_SeaLight.vim
+++ b/colors/Base2Tone_SeaLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_SpaceDark.vim
+++ b/colors/Base2Tone_SpaceDark.vim
@@ -335,6 +335,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui

--- a/colors/Base2Tone_SpaceLight.vim
+++ b/colors/Base2Tone_SpaceLight.vim
@@ -336,6 +336,26 @@ call <sid>hi("SpellRare",    "", s:gui00, "", s:cterm00, "undercurl")
 " fugitive higlighthing
 call <sid>hi("gitCommitSummary",  s:gui07, "", s:cterm07, "none", "none")
 
+" neovim terminal
+if has('nvim')
+  let g:terminal_color_0  = "#" . s:gui00
+  let g:terminal_color_1  = "#" . s:gui01
+  let g:terminal_color_2  = "#" . s:gui02
+  let g:terminal_color_3  = "#" . s:gui03
+  let g:terminal_color_4  = "#" . s:gui04
+  let g:terminal_color_5  = "#" . s:gui05
+  let g:terminal_color_6  = "#" . s:gui06
+  let g:terminal_color_7  = "#" . s:gui07
+  let g:terminal_color_8  = "#" . s:gui08
+  let g:terminal_color_9  = "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui0A
+  let g:terminal_color_11 = "#" . s:gui0B
+  let g:terminal_color_12 = "#" . s:gui0C
+  let g:terminal_color_13 = "#" . s:gui0D
+  let g:terminal_color_14 = "#" . s:gui0E
+  let g:terminal_color_15 = "#" . s:gui0F
+endif
+
 " Remove functions
 delf <sid>hi
 delf <sid>gui


### PR DESCRIPTION
Thanks for the port of this awesome colorscheme! 

I've been using the `PoolDark` colors for well over a year now but realised that the terminal colors in vim weren't specified. This seems to resolve that by using the same `gui<hex>` colors.